### PR TITLE
Improve dashboard layout and dark mode

### DIFF
--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -1,0 +1,79 @@
+:root {
+  --font-family: 'Poppins', sans-serif;
+  --auth-bg: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  --dashboard-bg: #f4f6f9;
+  --card-bg: #fff;
+  --text-color: #212529;
+  --link-color: #667eea;
+
+  --sidebar-bg: #fff;
+  --sidebar-text: #555;
+  --sidebar-active-bg: #e9ecef;
+  --sidebar-active-text: #333;
+}
+
+[data-theme="dark"] {
+  --auth-bg: linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%);
+  --dashboard-bg: #121212;
+  --card-bg: #1e1e1e;
+  --text-color: #e1e1e1;
+  --link-color: #9bbcff;
+  --sidebar-bg: #1e1e1e;
+  --sidebar-text: #ccc;
+  --sidebar-active-bg: #333;
+  --sidebar-active-text: #fff;
+}
+
+body {
+  font-family: var(--font-family);
+  color: var(--text-color);
+}
+
+.auth-page {
+  background: var(--auth-bg);
+  min-height: 100vh;
+}
+
+.dashboard-page {
+  background: var(--dashboard-bg);
+  min-height: 100vh;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 1rem;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+}
+
+.form-control:focus {
+  box-shadow: 0 0 0 0.2rem rgba(102,126,234,0.25);
+}
+
+a {
+  color: var(--link-color);
+}
+
+.sidebar {
+  background: var(--sidebar-bg);
+  min-height: calc(100vh - 56px);
+  width: 250px;
+  border-right: 1px solid #e0e0e0;
+}
+
+.sidebar .nav-link {
+  color: var(--sidebar-text);
+  font-weight: 500;
+  padding: 0.75rem 1rem;
+}
+
+.sidebar .nav-link.active {
+  background: var(--sidebar-active-bg);
+  color: var(--sidebar-active-text);
+  border-radius: 0.375rem;
+}
+
+#themeToggle {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}

--- a/app/public/dashboard.html
+++ b/app/public/dashboard.html
@@ -17,47 +17,28 @@
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
   >
-  <style>
-    body {
-      font-family: 'Poppins', sans-serif;
-      background: #f4f6f9;
-    }
-    .sidebar {
-      background: #fff;
-      min-height: calc(100vh - 56px);
-      width: 250px;
-      border-right: 1px solid #e0e0e0;
-    }
-    .sidebar .nav-link {
-      color: #555;
-      font-weight: 500;
-      padding: 0.75rem 1rem;
-    }
-    .sidebar .nav-link.active {
-      background: #e9ecef;
-      color: #333;
-      border-radius: 0.375rem;
-    }
-    .card {
-      border-radius: 1rem;
-      box-shadow: 0 2px 15px rgba(0,0,0,0.05);
-    }
-  </style>
+  <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="dashboard-page">
   <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg navbar-white bg-white shadow-sm">
+  <nav class="navbar navbar-expand-lg navbar-white bg-white shadow-sm position-relative">
     <div class="container-fluid">
-      <a class="navbar-brand fw-bold" href="#">SecureAuth</a>
-      <button class="btn btn-outline-danger" id="logoutBtn">
-        <i class="bi bi-box-arrow-right me-1"></i>Cerrar sesión
+      <button class="navbar-toggler d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarOffcanvas">
+        <span class="navbar-toggler-icon"></span>
       </button>
+      <a class="navbar-brand fw-bold" href="#">SecureAuth</a>
+      <div class="ms-auto d-flex align-items-center gap-2">
+        <button id="themeToggle" class="btn btn-secondary"><i class="bi bi-moon-fill"></i></button>
+        <button class="btn btn-outline-danger" id="logoutBtn">
+          <i class="bi bi-box-arrow-right me-1"></i>Cerrar sesión
+        </button>
+      </div>
     </div>
   </nav>
 
   <div class="d-flex">
     <!-- Sidebar -->
-    <nav class="sidebar p-3">
+    <nav class="sidebar p-3 d-none d-lg-block">
       <ul class="nav nav-pills flex-column mb-auto">
         <li class="nav-item mb-2">
           <a href="#" id="linkProfile" class="nav-link active">
@@ -76,6 +57,29 @@
         </li>
       </ul>
     </nav>
+
+    <!-- Offcanvas sidebar -->
+    <div class="offcanvas offcanvas-start d-lg-none" tabindex="-1" id="sidebarOffcanvas">
+      <div class="p-3">
+        <ul class="nav nav-pills flex-column mb-auto">
+          <li class="nav-item mb-2">
+            <a href="#" id="linkProfile2" class="nav-link active">
+              <i class="bi bi-person-circle me-1"></i> Perfil
+            </a>
+          </li>
+          <li class="nav-item mb-2">
+            <a href="#" id="linkChange2" class="nav-link">
+              <i class="bi bi-key-fill me-1"></i> Cambiar contraseña
+            </a>
+          </li>
+          <li class="nav-item mb-2">
+            <a href="#" id="linkOther2" class="nav-link">
+              <i class="bi bi-gear-fill me-1"></i> Otras funciones
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
 
     <!-- Main content -->
     <main class="flex-grow-1 p-4">

--- a/app/public/forgot.html
+++ b/app/public/forgot.html
@@ -17,23 +17,10 @@
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
   >
-  <style>
-    body {
-      font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      min-height: 100vh;
-    }
-    .card {
-      border-radius: 1rem;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-    }
-    .form-control:focus {
-      box-shadow: 0 0 0 0.2rem rgba(102,126,234,0.25);
-    }
-    a { color: #667eea; }
-  </style>
+  <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="auth-page">
+  <button id="themeToggle" class="btn btn-secondary"><i class="bi bi-moon-fill"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
     <div class="card p-4 bg-white w-100" style="max-width: 400px;">
       <h4 class="card-title text-center mb-3 fw-semibold">

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -17,25 +17,10 @@
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
   >
-  <style>
-    body {
-      font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      min-height: 100vh;
-    }
-    .card {
-      border-radius: 1rem;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-    }
-    .form-control:focus {
-      box-shadow: 0 0 0 0.2rem rgba(102,126,234,0.25);
-    }
-    a {
-      color: #667eea;
-    }
-  </style>
+  <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="auth-page">
+  <button id="themeToggle" class="btn btn-secondary"><i class="bi bi-moon-fill"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
     <div class="card p-4 bg-white w-100" style="max-width: 400px;">
       <h4 class="card-title text-center mb-3 fw-semibold">Iniciar Sesión</h4>

--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -6,6 +6,27 @@ document.addEventListener('DOMContentLoaded', () => {
     const resetForm     = document.getElementById('resetForm');
     const changeForm    = document.getElementById('changeForm');
     const username      = localStorage.getItem('username');
+    const themeToggle   = document.getElementById('themeToggle');
+
+    function applyTheme(theme) {
+      if (theme === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        if (themeToggle) themeToggle.innerHTML = '<i class="bi bi-sun-fill"></i>';
+      } else {
+        document.documentElement.removeAttribute('data-theme');
+        if (themeToggle) themeToggle.innerHTML = '<i class="bi bi-moon-fill"></i>';
+      }
+    }
+
+    if (themeToggle) {
+      applyTheme(localStorage.getItem('theme'));
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const newTheme = isDark ? 'light' : 'dark';
+        localStorage.setItem('theme', newTheme);
+        applyTheme(newTheme);
+      });
+    }
   
     // Helper para mostrar alertas
     function showAlert(containerId, msg, type) {
@@ -160,15 +181,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (userSpan) {
       userSpan.textContent = username;
       const main = document.getElementById('mainContent');
-  
-      document.getElementById('linkProfile').addEventListener('click', () => {
+
+      const profileFns = () => {
         main.innerHTML = `
           <h4>Perfil de usuario</h4>
           <p>Bienvenido, <strong>${username}</strong>.</p>
         `;
-      });
-  
-      document.getElementById('linkChange').addEventListener('click', () => {
+      };
+
+      const changeFn = () => {
         main.innerHTML = `
           <h4>Cambiar contraseña</h4>
           <div id="changeAlert"></div>
@@ -184,17 +205,31 @@ document.addEventListener('DOMContentLoaded', () => {
             <button class="btn btn-success">Actualizar</button>
           </form>
         `;
-        // reenganchar listener de changeForm tras inyección
         const evt = new Event('DOMContentLoaded');
         document.dispatchEvent(evt);
-      });
-  
-      document.getElementById('linkOther').addEventListener('click', () => {
+      };
+
+      const otherFn = () => {
         main.innerHTML = `
           <h4>Otras funciones</h4>
           <p>Aquí puedes agregar más opciones.</p>
         `;
+      };
+
+      ['linkProfile','linkProfile2'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('click', profileFns);
+      });
+
+      ['linkChange','linkChange2'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('click', changeFn);
+      });
+
+      ['linkOther','linkOther2'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('click', otherFn);
       });
     }
   });
-  
+ 

--- a/app/public/register.html
+++ b/app/public/register.html
@@ -17,23 +17,10 @@
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
   >
-  <style>
-    body {
-      font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      min-height: 100vh;
-    }
-    .card {
-      border-radius: 1rem;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-    }
-    .form-control:focus {
-      box-shadow: 0 0 0 0.2rem rgba(102,126,234,0.25);
-    }
-    a { color: #667eea; }
-  </style>
+  <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="auth-page">
+  <button id="themeToggle" class="btn btn-secondary"><i class="bi bi-moon-fill"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
     <div class="card p-4 bg-white w-100" style="max-width: 450px;">
       <h4 class="card-title text-center mb-3 fw-semibold">

--- a/app/public/reset.html
+++ b/app/public/reset.html
@@ -17,23 +17,10 @@
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
   >
-  <style>
-    body {
-      font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      min-height: 100vh;
-    }
-    .card {
-      border-radius: 1rem;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-    }
-    .form-control:focus {
-      box-shadow: 0 0 0 0.2rem rgba(102,126,234,0.25);
-    }
-    a { color: #667eea; }
-  </style>
+  <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="auth-page">
+  <button id="themeToggle" class="btn btn-secondary"><i class="bi bi-moon-fill"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
     <div class="card p-4 bg-white w-100" style="max-width: 400px;">
       <h4 class="card-title text-center mb-3 fw-semibold">


### PR DESCRIPTION
## Summary
- centralize global styles in new `style.css`
- add dark mode variables and theme toggle button
- refactor all pages to use shared CSS
- make dashboard sidebar responsive with offcanvas menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c46e26d48320a3c60913bde68cfa