### PR TITLE
Refine login UI

### DIFF
--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -1,6 +1,6 @@
 :root {
   --font-family: 'Poppins', sans-serif;
-  --auth-bg: linear-gradient(120deg, #a1c4fd 0%, #c2e9fb 100%);
+  --auth-bg: linear-gradient(120deg, #eceff4 0%, #f7f8fa 100%);
   --dashboard-bg: #f4f6f9;
   --card-bg: #fff;
   --text-color: #212529;
@@ -27,6 +27,7 @@
 body {
   font-family: var(--font-family);
   color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .auth-page {
@@ -37,6 +38,10 @@ body {
 .auth-header {
   margin-bottom: 2rem;
   background: transparent;
+}
+
+.app-logo {
+  font-size: 1.75rem;
 }
 
 .auth-content {
@@ -55,6 +60,13 @@ body {
   background: var(--card-bg);
   border-radius: 1rem;
   box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.card-title {
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-bottom: 1.5rem;
 }
 
 .form-control:focus {
@@ -64,6 +76,10 @@ body {
 .auth-page .form-control,
 .auth-page button[type="submit"] {
   transition: all 0.2s ease-in-out;
+}
+
+.toggle-password {
+  transition: color 0.2s ease;
 }
 
 a {
@@ -90,8 +106,5 @@ a {
 }
 
 #themeToggle {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 1000;
+  position: relative;
 }

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -21,8 +21,8 @@
 </head>
 <body class="auth-page">
   <header class="auth-header container d-flex justify-content-between align-items-center">
-    <h1 class="fs-4 fw-bold m-0">SecureAuth</h1>
-    <button id="themeToggle" class="btn btn-secondary"><i class="bi bi-moon-fill"></i></button>
+    <h1 class="app-logo fw-bold m-0">SecureAuth</h1>
+    <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill"></i></button>
   </header>
   <div class="container auth-content d-flex align-items-center justify-content-center">
     <div class="card p-4 bg-white w-100" style="max-width: 400px;">
@@ -45,19 +45,24 @@
           <label for="password" class="form-label fw-medium">
             <i class="bi bi-lock-fill me-1"></i> Contraseña
           </label>
-          <input
-            type="password"
-            id="password"
-            class="form-control"
-            placeholder="••••••••"
-            required
-          >
+          <div class="input-group">
+            <input
+              type="password"
+              id="password"
+              class="form-control"
+              placeholder="••••••••"
+              required
+            >
+            <button type="button" class="btn btn-outline-secondary toggle-password" aria-label="Mostrar contraseña">
+              <i class="bi bi-eye"></i>
+            </button>
+          </div>
         </div>
         <button type="submit" class="btn btn-primary w-100 fw-bold">Entrar</button>
       </form>
-      <div class="d-flex justify-content-between mt-3">
-        <a href="register.html" class="small"><i class="bi bi-person-plus-fill me-1"></i>Crear cuenta</a>
-        <a href="forgot.html" class="small"><i class="bi bi-key-fill me-1"></i>Olvidé mi contraseña</a>
+      <div class="d-flex flex-column gap-1 text-center mt-3 small">
+        <a href="register.html"><i class="bi bi-person-plus-fill me-1"></i>Crear cuenta</a>
+        <a href="forgot.html"><i class="bi bi-key-fill me-1"></i>Olvidé mi contraseña</a>
       </div>
     </div>
   </div>

--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const changeForm    = document.getElementById('changeForm');
     const username      = localStorage.getItem('username');
     const themeToggle   = document.getElementById('themeToggle');
+    const togglePwBtns  = document.querySelectorAll('.toggle-password');
 
     function applyTheme(theme) {
       if (theme === 'dark') {
@@ -25,6 +26,19 @@ document.addEventListener('DOMContentLoaded', () => {
         const newTheme = isDark ? 'light' : 'dark';
         localStorage.setItem('theme', newTheme);
         applyTheme(newTheme);
+      });
+    }
+
+    if (togglePwBtns) {
+      togglePwBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const input = btn.closest('.input-group').querySelector('input');
+          if (!input) return;
+          const show = input.type === 'password';
+          input.type = show ? 'text' : 'password';
+          btn.innerHTML = show ? '<i class="bi bi-eye-slash"></i>' : '<i class="bi bi-eye"></i>';
+          btn.setAttribute('aria-label', show ? 'Ocultar contraseña' : 'Mostrar contraseña');
+        });
       });
     }
   


### PR DESCRIPTION
## Summary
- redesign login page with larger header logo
- add toggleable password visibility with aria labels
- align theme toggle with header
- introduce neutral theme colors and transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c8811e98832089e0c2a6eb5b4393