### PR TITLE
Update auth pages header layout

### DIFF
--- a/app/public/forgot.html
+++ b/app/public/forgot.html
@@ -20,8 +20,11 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="auth-page">
-  <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
-  <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
+  <header class="auth-header container d-flex justify-content-between align-items-center">
+    <h1 class="app-logo fw-bold m-0">SecureAuth</h1>
+    <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
+  </header>
+  <div class="container auth-content d-flex align-items-center justify-content-center">
     <div class="card p-4 bg-white w-100" style="max-width: 400px;">
       <h4 class="card-title text-center mb-3 fw-semibold">
         <i class="bi bi-key-fill me-1" aria-hidden="true"></i>¿Olvidaste tu contraseña?

--- a/app/public/register.html
+++ b/app/public/register.html
@@ -20,8 +20,11 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="auth-page">
-  <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
-  <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
+  <header class="auth-header container d-flex justify-content-between align-items-center">
+    <h1 class="app-logo fw-bold m-0">SecureAuth</h1>
+    <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
+  </header>
+  <div class="container auth-content d-flex align-items-center justify-content-center">
     <div class="card p-4 bg-white w-100" style="max-width: 450px;">
       <h4 class="card-title text-center mb-3 fw-semibold">
         <i class="bi bi-person-plus-fill me-1" aria-hidden="true"></i>Crear Cuenta

--- a/app/public/reset.html
+++ b/app/public/reset.html
@@ -20,8 +20,11 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="auth-page">
-  <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
-  <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
+  <header class="auth-header container d-flex justify-content-between align-items-center">
+    <h1 class="app-logo fw-bold m-0">SecureAuth</h1>
+    <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
+  </header>
+  <div class="container auth-content d-flex align-items-center justify-content-center">
     <div class="card p-4 bg-white w-100" style="max-width: 400px;">
       <h4 class="card-title text-center mb-3 fw-semibold">
         <i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i>Restablecer contraseña


### PR DESCRIPTION
## Summary
- use the same header markup from index.html on register/forgot/reset pages
- swap inline min-height containers with `.auth-content` container
- keep css/style.css import on all pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684209651bf48320a40e1f1525b28d26