### PR TITLE
Apply auth card CSS class

### DIFF
--- a/app/public/css/modules/components.css
+++ b/app/public/css/modules/components.css
@@ -47,3 +47,8 @@ a {
 #themeToggle {
   position: relative;
 }
+
+/* Card container for authentication pages */
+.auth-card {
+  max-width: 400px;
+}

--- a/app/public/forgot.html
+++ b/app/public/forgot.html
@@ -22,7 +22,7 @@
 <body class="auth-page">
   <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
-    <div class="card p-4 bg-white w-100" style="max-width: 400px;">
+    <div class="card auth-card p-4 bg-white w-100">
       <h4 class="card-title text-center mb-3 fw-semibold">
         <i class="bi bi-key-fill me-1" aria-hidden="true"></i>¿Olvidaste tu contraseña?
       </h4>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -25,7 +25,7 @@
     <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
   </header>
   <div class="container auth-content d-flex align-items-center justify-content-center">
-    <div class="card p-4 bg-white w-100" style="max-width: 400px;">
+    <div class="card auth-card p-4 bg-white w-100">
       <h4 class="card-title text-center mb-3 fw-semibold">Iniciar Sesión</h4>
       <div id="loginAlert"></div>
       <form id="loginForm">

--- a/app/public/register.html
+++ b/app/public/register.html
@@ -22,7 +22,7 @@
 <body class="auth-page">
   <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
-    <div class="card p-4 bg-white w-100" style="max-width: 450px;">
+    <div class="card auth-card p-4 bg-white w-100">
       <h4 class="card-title text-center mb-3 fw-semibold">
         <i class="bi bi-person-plus-fill me-1" aria-hidden="true"></i>Crear Cuenta
       </h4>

--- a/app/public/reset.html
+++ b/app/public/reset.html
@@ -22,7 +22,7 @@
 <body class="auth-page">
   <button id="themeToggle" class="btn btn-secondary" aria-label="Cambiar tema"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
   <div class="container d-flex align-items-center justify-content-center" style="min-height:100vh;">
-    <div class="card p-4 bg-white w-100" style="max-width: 400px;">
+    <div class="card auth-card p-4 bg-white w-100">
       <h4 class="card-title text-center mb-3 fw-semibold">
         <i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i>Restablecer contraseña
       </h4>


### PR DESCRIPTION
## Summary
- add `.auth-card` CSS helper
- use `.auth-card` on login, register, forgot, and reset pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684209667ea483208287daf22b95a893