### PR TITLE
Refactor generateUser script

### DIFF
--- a/app/generateUser.js
+++ b/app/generateUser.js
@@ -1,8 +1,10 @@
 // generateUser.js
-const { genSalt, sha256 } = require('./utils/hash');
+// Utility script that prints the bcrypt hash of a sample password.
+const { hashPassword } = require('./utils/hash');
 
-const salt = genSalt();
-const hash = sha256('MiPass123', salt);
-
-console.log('SALT=', salt);
-console.log('HASH=', hash);
+(async () => {
+  const password = 'MiPass123';
+  const hash = await hashPassword(password);
+  console.log('PASSWORD=', password);
+  console.log('HASH=', hash);
+})();


### PR DESCRIPTION
## Summary
- use `hashPassword` in generateUser script
- document the script's purpose

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68435c4e51c48320b95df9f9ce461ed0