### PR TITLE
Make cookie secure flag environment-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Alternatively you can use the helper script in the repository root:
 ```
 
 It will install dependencies in `app` (if not already installed) and then run the test suite.
+
+## Authentication Cookie
+
+When you log in, the server sends a `token` cookie containing the session JWT. The `secure` attribute of this cookie depends on the `NODE_ENV` environment variable: it is only enabled in production. In development the cookie is also served over HTTP for convenience.

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -100,7 +100,12 @@ router.post('/login', async (req, res) => {
       process.env.JWT_SECRET,
       { expiresIn: '1h' }
     );
-    res.cookie('token', token, { httpOnly: true, secure: true, sameSite: 'strict' });
+    const secureCookie = process.env.NODE_ENV === 'production';
+    res.cookie('token', token, {
+      httpOnly: true,
+      secure: secureCookie,
+      sameSite: 'strict'
+    });
     res.json({ message: 'Login exitoso' });
   } finally {
     conn.release();


### PR DESCRIPTION
## Summary
- only set the login cookie's `secure` flag when NODE_ENV is `production`
- document cookie behavior in README

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68435c4f209c8320ac29ffad7c06ab72