### PR TITLE
Use env vars for sync script

### DIFF
--- a/sync_usuarios.env.example
+++ b/sync_usuarios.env.example
@@ -1,0 +1,13 @@
+# Environment variables for sync_usuarios.py
+
+# Oracle connection
+ORACLE_USER=SYSTEM
+ORACLE_PASSWORD=your_oracle_password
+ORACLE_DSN=localhost:1521/xe
+
+# MySQL connection
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_USER=root
+MYSQL_PASSWORD=your_mysql_password
+MYSQL_DB=sys

--- a/sync_usuarios.py
+++ b/sync_usuarios.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
+import os
 import cx_Oracle
 import mysql.connector
 from datetime import datetime
 
 # ----- PARÁMETROS DE CONEXIÓN -----
-# Oracle XE (SID = xe) en localhost:1521
+# Las credenciales se obtienen de variables de entorno
 ora_conn = cx_Oracle.connect(
-    user='SYSTEM',
-    password='juan12',
-    dsn='localhost:1521/xe'
+    user=os.getenv("ORACLE_USER"),
+    password=os.getenv("ORACLE_PASSWORD"),
+    dsn=os.getenv("ORACLE_DSN"),
 )
 
-# MySQL – base de réplica, no uses 'sys'
 my_conn = mysql.connector.connect(
-    host='localhost',
-    port=3306,
-    user='root',
-    password='juan12',
-    database='sys'      # <- cambia esto por tu réplica
+    host=os.getenv("MYSQL_HOST"),
+    port=int(os.getenv("MYSQL_PORT", "3306")),
+    user=os.getenv("MYSQL_USER"),
+    password=os.getenv("MYSQL_PASSWORD"),
+    database=os.getenv("MYSQL_DB"),  # <- cambia esto por tu réplica
 )
 
 def get_last_sync(cursor):


### PR DESCRIPTION
## Summary
- load Oracle and MySQL credentials using os.getenv
- add example env file for sync_usuarios.py

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68435c50a59883209b36c349d8c7ce93